### PR TITLE
Relax validation for preflight source paths

### DIFF
--- a/onto_mcp/resources.py
+++ b/onto_mcp/resources.py
@@ -60,6 +60,7 @@ def preflight_plan(
     source = source.strip()
 
     source_path = source
+    safe_print(f"[preflight_plan] source: {source_path}")
 
     is_posix_absolute = bool(source_path) and PurePosixPath(source_path).is_absolute()
     if not (is_posix_absolute or _is_windows_absolute_path(source_path)):


### PR DESCRIPTION
## Summary
- detect absolute paths using pathlib to handle Windows drive letters, UNC shares, and extended prefixes
- stop checking for server-side file existence so client-only absolute paths pass validation
- default the payload builder environment to blanks while keeping the Python snippet's utf-8 fallback
- print the provided source path when building the payload to make the processed file explicit

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9a61e17748327bf4aceebfa64296e