### PR TITLE
Log build version at startup and refine preflight plan

### DIFF
--- a/onto_mcp/resources.py
+++ b/onto_mcp/resources.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import os  # Still used for sys.path adjustments in tests; keep for now
+import os
 from fastmcp import FastMCP
+from fastmcp.exceptions import ValidationError
 from fastmcp.server.context import Context
 import requests
 import uuid
@@ -19,10 +20,134 @@ from .utils import safe_print
 
 mcp = FastMCP(name="Onto MCP Server")
 
+BUILD_VERSION = os.environ.get("ONTO_BUILD_VERSION") or "0.1.0"
+
+safe_print(f"[startup] Onto MCP build version: {BUILD_VERSION}")
+
 # ONTO_API_BASE now comes from settings (with env/default handling)
 
 # Global Keycloak auth instance
 keycloak_auth = KeycloakAuth()
+@mcp.tool
+def preflight_plan(
+    source: str,
+    forceSep: str | None = None,
+    forceEncoding: str | None = None,
+) -> Dict[str, Any]:
+    """Return a two-step plan for building and submitting a CSV signature."""
+
+    if not isinstance(source, str) or not source.strip():
+        raise ValidationError("400: 'source' is required and must be a non-empty string.")
+
+    source = source.strip()
+
+    source_path = source
+    safe_print(f"[preflight_plan] received source: {source_path}")
+
+    if not os.path.isabs(source_path):
+        safe_print("[preflight_plan] rejected source: path is not absolute")
+        raise ValidationError("400: 'source' must be an absolute path to a local file.")
+
+    if not os.path.isfile(source_path):
+        safe_print("[preflight_plan] rejected source: file does not exist locally")
+        raise ValidationError("404: 'source' must reference an existing local file.")
+
+    try:
+        file_size = os.path.getsize(source_path)
+    except OSError:
+        file_size = None
+
+    if file_size is not None:
+        safe_print(
+            f"[preflight_plan] confirmed local file exists (size={file_size} bytes)"
+        )
+    else:
+        safe_print("[preflight_plan] confirmed local file exists")
+
+    normalized_force_sep: str | None = None
+    if forceSep is not None:
+        if not isinstance(forceSep, str):
+            raise ValidationError("400: 'forceSep' must be null, ',' or ';'.")
+        normalized_force_sep = forceSep.strip()
+        if normalized_force_sep not in (",", ";"):
+            raise ValidationError("400: 'forceSep' must be null, ',' or ';'.")
+
+    normalized_force_encoding: str | None = None
+    if forceEncoding is not None:
+        if not isinstance(forceEncoding, str):
+            raise ValidationError("400: 'forceEncoding' must be a string or null.")
+        normalized_force_encoding = forceEncoding.strip()
+        if not normalized_force_encoding:
+            raise ValidationError("400: 'forceEncoding' must be a non-empty string when provided.")
+
+    cmd = """python3 - <<'PY'
+import csv, re, json, hashlib, os, sys
+SRC = os.environ['SRC']
+def norm(s):
+  s=s.lower().strip().replace(' ','_').replace('-','_')
+  s=re.sub(r'[^a-z0-9_а-яё]','',s); s=re.sub(r'_+','_',s).strip('_'); return s
+
+# авто-детект разделителя (можно переопределить env FORCE_SEP)
+with open(SRC,'rb') as f: head=f.read(256*1024)
+sep = ';' if head.count(b';')>head.count(b',') else ','
+force_sep = os.environ.get('FORCE_SEP')
+if force_sep in (',',';'): sep = force_sep
+
+enc = os.environ.get('FORCE_ENCODING') or 'utf-8'
+
+with open(SRC, encoding=enc, newline='') as f:
+  rdr = csv.reader(f, delimiter=sep)
+  raw = next(rdr)
+  headers = [norm(h) for h in raw]
+
+hdr = ';'.join(headers)
+payload = {
+  "fileName": os.path.basename(SRC),
+  "fileSize": os.path.getsize(SRC),
+  "signature": {
+    "encoding": enc,
+    "sep": sep,
+    "hasHeader": True,
+    "numCols": len(headers),
+    "headers": headers,
+    "headerHash": "sha256:"+hashlib.sha256(hdr.encode()).hexdigest(),
+    "headerSortedHash": "sha256:"+hashlib.sha256(';'.join(sorted(headers)).encode()).hexdigest(),
+    "stats": {"rowsScanned": 0}
+  }
+}
+open('payload.json','w',encoding='utf-8').write(json.dumps(payload,ensure_ascii=False,indent=2))
+print("OK -> payload.json")
+PY"""
+
+    actions = [
+        {
+            "type": "shell",
+            "name": "build-signature",
+            "cmd": cmd,
+            "env": {
+                "SRC": source_path,
+                "FORCE_SEP": normalized_force_sep or "",
+                "FORCE_ENCODING": normalized_force_encoding or "",
+            },
+        },
+        {
+            "type": "mcp_call",
+            "name": "send-signature",
+            "tool": "preflight_submit",
+            "args_from_file": "payload.json",
+        },
+    ]
+
+    notes = [
+        "Команда создаст payload.json в текущей директории клиента",
+    ]
+
+    return {
+        "buildVersion": BUILD_VERSION,
+        "actions": actions,
+        "notes": notes,
+    }
+
 
 def _legacy_token_storage_enabled() -> bool:
     return getattr(keycloak_auth.token_storage, "supports_legacy_token", True)


### PR DESCRIPTION
## Summary
- print the Onto MCP build version during server startup for easier observability
- align the preflight_plan shell payload generation with the provided snippet and keep notes minimal per the specification

## Testing
- python -m compileall onto_mcp/resources.py

------
https://chatgpt.com/codex/tasks/task_e_68d9a61e17748327bf4aceebfa64296e