### PR TITLE
Add MinIO upload tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,7 +67,10 @@ coverage.xml
 ehthumbs.db
 Thumbs.db
 
-# Development scripts and testing files
+# Development scripts
 dev-scripts/
-tests/
+
+# Keep committed test suite
+!tests/
+!tests/**
 

--- a/onto_mcp/upload_service.py
+++ b/onto_mcp/upload_service.py
@@ -1,0 +1,137 @@
+"""Utilities for interacting with Onto storage upload API."""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
+
+import requests
+
+from .settings import ONTO_API_BASE, ONTO_API_TOKEN, ONTO_REALM_ID
+from .utils import safe_print
+
+
+class UploadServiceError(RuntimeError):
+    """Raised when the storage upload API returns an error."""
+
+    def __init__(self, message: str, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code or 500
+
+
+@dataclass
+class UploadServiceConfig:
+    api_base: str
+    api_token: str
+    realm_id: str
+
+
+class UploadService:
+    """Small helper around the Onto storage upload API."""
+
+    MAX_RETRIES = 3
+    TIMEOUT_SECONDS = 30
+
+    def __init__(self, config: UploadServiceConfig | None = None) -> None:
+        if config is None:
+            api_base = (ONTO_API_BASE or "").rstrip("/")
+            api_token = (ONTO_API_TOKEN or "").strip()
+            realm_id = (ONTO_REALM_ID or "").strip()
+            config = UploadServiceConfig(api_base=api_base, api_token=api_token, realm_id=realm_id)
+
+        if not config.api_base or not config.api_token or not config.realm_id:
+            raise UploadServiceError(
+                "Storage upload API is not configured. "
+                "Please provide ONTO_API_BASE, ONTO_API_TOKEN and ONTO_REALM_ID.",
+                status_code=500,
+            )
+
+        self.config = config
+        self.session = requests.Session()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def request_upload_url(self, payload: Dict[str, Any]) -> Tuple[Dict[str, Any], str]:
+        """Request presigned upload URL(s) from the Onto storage API."""
+
+        path = f"/realm/{self.config.realm_id}/storage/upload-url"
+        return self._request("POST", path, payload)
+
+    def complete_upload(self, payload: Dict[str, Any]) -> Tuple[Dict[str, Any], str]:
+        """Notify Onto that the upload has been completed."""
+
+        path = f"/realm/{self.config.realm_id}/storage/upload-complete"
+        return self._request("POST", path, payload)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _request(self, method: str, path: str, payload: Optional[Dict[str, Any]]) -> Tuple[Dict[str, Any], str]:
+        url = f"{self.config.api_base}{path}"
+        request_id = uuid.uuid4().hex
+        headers = {
+            "X-API-Key": self.config.api_token,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "X-Request-Id": request_id,
+        }
+
+        last_error: Optional[str] = None
+        for attempt in range(1, self.MAX_RETRIES + 1):
+            try:
+                response = self.session.request(
+                    method,
+                    url,
+                    json=payload if method.upper() != "GET" else None,
+                    timeout=self.TIMEOUT_SECONDS,
+                    headers=headers,
+                )
+            except requests.RequestException as exc:
+                last_error = str(exc)
+                safe_print(
+                    f"[upload_service] network error on {method.upper()} {path} (attempt {attempt}/{self.MAX_RETRIES}): {exc}"
+                )
+                if attempt == self.MAX_RETRIES:
+                    raise UploadServiceError(f"failed to reach storage API: {exc}", status_code=502) from exc
+                continue
+
+            if response.status_code >= 500:
+                last_error = f"storage API error {response.status_code}: {response.text.strip()}"
+                safe_print(
+                    f"[upload_service] server error {response.status_code} on {method.upper()} {path} (attempt {attempt}/{self.MAX_RETRIES})"
+                )
+                if attempt == self.MAX_RETRIES:
+                    raise UploadServiceError(last_error, status_code=502)
+                continue
+
+            if response.status_code >= 400:
+                raise UploadServiceError(
+                    f"storage API error {response.status_code}: {response.text.strip()}",
+                    status_code=response.status_code,
+                )
+
+            if response.status_code == 204:
+                return {}, request_id
+
+            try:
+                data = response.json()
+            except ValueError as exc:
+                raise UploadServiceError(
+                    f"storage API returned invalid JSON: {exc}", status_code=502
+                ) from exc
+
+            if not isinstance(data, dict):
+                raise UploadServiceError(
+                    "storage API returned unexpected payload (expected object)",
+                    status_code=502,
+                )
+
+            return data, request_id
+
+        raise UploadServiceError(last_error or "failed to reach storage API", status_code=502)
+
+
+__all__ = ["UploadService", "UploadServiceError", "UploadServiceConfig"]
+

--- a/tests/test_upload_tools.py
+++ b/tests/test_upload_tools.py
@@ -1,0 +1,163 @@
+"""Tests for upload_url and upload_complete tools."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import os
+import pathlib
+import sys
+
+import pytest
+from fastmcp.exceptions import ValidationError
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("KEYCLOAK_BASE_URL", "https://example.com")
+os.environ.setdefault("KEYCLOAK_REALM", "example")
+os.environ.setdefault("KEYCLOAK_CLIENT_ID", "client")
+os.environ.setdefault("ONTO_API_BASE", "https://api.example.com")
+os.environ.setdefault("ONTO_API_TOKEN", "token")
+os.environ.setdefault("ONTO_REALM_ID", "realm-123")
+
+from onto_mcp import resources
+
+upload_url = resources.upload_url.fn
+upload_complete = resources.upload_complete.fn
+
+
+class DummyUploadService:
+    def __init__(self) -> None:
+        self.captured_payload: Dict[str, Any] | None = None
+        self.config = type("Cfg", (), {"realm_id": "realm-123"})()
+        self._response: Dict[str, Any] = {}
+        self._request_id = "req-test"
+
+    def set_response(self, response: Dict[str, Any], request_id: str = "req-test") -> None:
+        self._response = response
+        self._request_id = request_id
+
+    def request_upload_url(self, payload: Dict[str, Any]):
+        self.captured_payload = payload
+        return self._response, self._request_id
+
+    def complete_upload(self, payload: Dict[str, Any]):
+        self.captured_payload = payload
+        return self._response, self._request_id
+
+
+@pytest.fixture(autouse=True)
+def ensure_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(resources, "UploadService", lambda: DummyUploadService())
+
+
+def test_upload_url_requires_raw_prefix() -> None:
+    with pytest.raises(ValidationError) as exc:
+        upload_url(
+            s3Key="dataset/source.csv",
+            fileName="file.csv",
+            fileSize=10,
+            contentType="text/csv",
+        )
+
+    assert "s3Key" in str(exc.value)
+
+
+def test_upload_url_auto_single_invokes_service(monkeypatch: pytest.MonkeyPatch) -> None:
+    dummy = DummyUploadService()
+    dummy.set_response(
+        {
+            "mode": "single",
+            "s3Key": "raw/ds/2024/01/source-1.csv",
+            "putUrl": "https://minio/single",
+            "expiresInSec": 3600,
+            "headers": {"Content-Type": "text/csv"},
+        },
+        request_id="req-123",
+    )
+    monkeypatch.setattr(resources, "UploadService", lambda: dummy)
+
+    result = upload_url(
+        s3Key="raw/ds/2024/01/source-1.csv",
+        fileName="source-1.csv",
+        fileSize=1024,
+        contentType="text/csv",
+    )
+
+    assert result["mode"] == "single"
+    assert dummy.captured_payload is not None
+    assert dummy.captured_payload["mode"] == "single"
+    assert dummy.captured_payload["strategy"] == "auto"
+
+
+def test_upload_url_auto_switches_to_multipart(monkeypatch: pytest.MonkeyPatch) -> None:
+    dummy = DummyUploadService()
+    dummy.set_response(
+        {
+            "mode": "multipart",
+            "s3Key": "raw/ds/2024/01/source-2.csv",
+            "uploadId": "u-123",
+            "partSize": 64 * 1024 * 1024,
+            "parts": [
+                {"partNumber": 1, "putUrl": "https://minio/part1"},
+                {"partNumber": 2, "putUrl": "https://minio/part2"},
+            ],
+            "completeUrl": "https://minio/complete",
+            "expiresInSec": 86400,
+        },
+        request_id="req-456",
+    )
+    monkeypatch.setattr(resources, "UploadService", lambda: dummy)
+
+    result = upload_url(
+        s3Key="raw/ds/2024/01/source-2.csv",
+        fileName="source-2.csv",
+        fileSize=6 * 1024 ** 3,
+        contentType="text/csv",
+    )
+
+    assert result["mode"] == "multipart"
+    assert dummy.captured_payload is not None
+    assert dummy.captured_payload["mode"] == "multipart"
+
+
+def test_upload_url_single_strategy_rejects_large_file() -> None:
+    with pytest.raises(ValidationError) as exc:
+        upload_url(
+            s3Key="raw/ds/2024/01/source-3.csv",
+            fileName="source-3.csv",
+            fileSize=6 * 1024 ** 3,
+            contentType="text/csv",
+            strategy="single",
+        )
+
+    assert "413" in str(exc.value)
+
+
+def test_upload_complete_requires_etag_or_parts() -> None:
+    with pytest.raises(ValidationError):
+        upload_complete(
+            s3Key="raw/ds/2024/01/source-1.csv",
+        )
+
+
+def test_upload_complete_with_parts(monkeypatch: pytest.MonkeyPatch) -> None:
+    dummy = DummyUploadService()
+    dummy.set_response({"ok": True, "size": 1234}, request_id="req-789")
+    monkeypatch.setattr(resources, "UploadService", lambda: dummy)
+
+    result = upload_complete(
+        s3Key="raw/ds/2024/01/source-1.csv",
+        parts=[
+            {"partNumber": 2, "eTag": "etag-2"},
+            {"partNumber": 1, "eTag": "etag-1"},
+        ],
+    )
+
+    assert result == {"ok": True, "size": 1234}
+    assert dummy.captured_payload is not None
+    assert dummy.captured_payload["parts"][0]["partNumber"] == 1
+    assert dummy.captured_payload["parts"][1]["partNumber"] == 2
+


### PR DESCRIPTION
## Summary
- add upload_url and upload_complete tools with validation for storage uploads
- implement an UploadService helper to call the Onto storage API
- keep the tests directory under version control and add coverage for the new tools

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc4ec786c48327a0bf119095e78c8c